### PR TITLE
Fix line_profiler requirement spelling

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,5 +6,5 @@
    - numba
    - jupyter
    - ipython
-   - line-profiler
+   - line_profiler
    - cython


### PR DESCRIPTION
When trying to setup the environment per the instructions, the line profiler requirement is not found:

```
>> master  conda env create -f environment.yml       
Fetching package metadata ...........

NoPackagesFoundError: Package missing in current osx-64 channels:
  - line-profiler
```

This PR fixes that by changing the spelling to the recognized `line_profiler`